### PR TITLE
Fix OPC UA write using wrong NodeId for non-zero namespace addresses

### DIFF
--- a/ProtocolDrivers/OPCUA/OPCUAAsset.cs
+++ b/ProtocolDrivers/OPCUA/OPCUAAsset.cs
@@ -271,9 +271,14 @@ namespace Opc.Ua.Edge.Translator.ProtocolDrivers
                 return Task.CompletedTask;
             }
 
+            // Resolve exactly as the read path does — new NodeId(string) ignores ns= prefixes.
+            NodeId nodeId = ExpandedNodeId.ToNodeId(
+                new ExpandedNodeId(addressWithinAsset),
+                _session.NamespaceUris);
+
             WriteValue nodeToWrite = new()
             {
-                NodeId = new NodeId(addressWithinAsset),
+                NodeId = nodeId,
                 Value = new DataValue(new Variant(value))
             };
 


### PR DESCRIPTION
Fixes #103

**Problem**
WriteValue constructed the target node as new NodeId(addressWithinAsset), which treats the entire address string as a string identifier in namespace 0. An address like ns=2;s=BG11.Value was sent to a non-existent or wrong node instead of namespace 2.

The read path already used the correct resolution (ExpandedNodeId.ToNodeId) since an earlier fix, so reads and writes were asymmetric for any tag in a non-zero namespace.

**Fix**
Resolve the write target the same way the read path does: